### PR TITLE
fix: typo as it seems docker only supports lowercased image names

### DIFF
--- a/docs/projects/visionBoard/installation.md
+++ b/docs/projects/visionBoard/installation.md
@@ -47,7 +47,7 @@ To use visionBoard via Docker:
 3. (Optional) Create an alias for convenience:
 
    ```bash
-   alias visionBoard="docker run --rm ghcr.io/openpathfinder/visionBoard:latest"
+   alias visionBoard="docker run --rm ghcr.io/openpathfinder/visionboard:latest"
    ```
 
 ## From Source Code


### PR DESCRIPTION
Just a simple typo fix (was surprised when tried and failed ☺️ )