### PR TITLE
docs: update check `noSensitiveInfoInRepositories`

### DIFF
--- a/docs/checks/noSensitiveInfoInRepositories.mdx
+++ b/docs/checks/noSensitiveInfoInRepositories.mdx
@@ -18,6 +18,12 @@ This check is currently under development and not yet implemented. [Click here t
 No secrets or credentials are included in the source code
 <!-- DESCRIPTION:END -->
 
+## VisionBoard Inclusion
+
+We checked the `secret_scanning_enabled_for_new_repositories` field in the GitHub Organization API and 
+the `secret_scanning_status` field in the GitHub Repositories API to verify if the project has enforced
+this policy, [more information](https://github.com/OpenPathfinder/visionBoard/issues/67)
+
 <!-- DETAILS:START -->
 ## Details
 - Default Category: service authentication


### PR DESCRIPTION
Related https://github.com/OpenPathfinder/visionBoard/issues/67

Probably a policy can be created for FortSphere